### PR TITLE
Use std::numeric_limits in place of DBL_MIN

### DIFF
--- a/TriangulatePolygon.h
+++ b/TriangulatePolygon.h
@@ -378,7 +378,7 @@ namespace triangulate
 
 		int maxIndex(-1);
 
-		double maxArea(DBL_MIN);
+		double maxArea(std::numeric_limits<double>::min());
 
 		for( size_t index = 0; index < n; index++ )
 		{


### PR DESCRIPTION
To use `DBL_MIN` we would need to include `<cfloat>` to compile cleanly (Apple Clang 15).

Instead, just C++-ify it and use `std::numeric_limits` since it's already used elsewhere.